### PR TITLE
fix: 대회번호로 대회 참가 기관 찾기 기능 오류 해결 #19

### DIFF
--- a/src/main/java/com/jul/jumpropetornamentchecker/service/CompetitionAttendService.java
+++ b/src/main/java/com/jul/jumpropetornamentchecker/service/CompetitionAttendService.java
@@ -190,6 +190,8 @@ public class CompetitionAttendService {
             Set<OrganizationResponseDto> competitionResponseDtoSet = new HashSet<>();
 
             competitionAttendDatum.forEach(data -> competitionResponseDtoSet.add(data.getOrganization().toDto()));
+            organizationDatum = new ArrayList<>(competitionResponseDtoSet);
+
         } catch (Exception e) {
             log.error(e.getMessage());
         }


### PR DESCRIPTION
찾은 데이터가 responseDto에 저장되지 않고 있던 문제 해결